### PR TITLE
Feature/identify module routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The module url for sentence writing is `/play/sw?uid&student`. It is assumed tha
 a `uid` parameter identifying the id of the sentence writing activity in Quill Grammar.
 The LMS may also pass a `student` parameter to identify the student.
 
+#### Proofreading Story
+
+The module url for story (proofreading activity) is `/play/pf?uid`. It is assumed that
+the LMS will add a `uid` parameter identifying the id of the proofreading story activity
+in Quill Grammar.
+
 Firebase Data
 =============
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Routes
 * `/play/partner-pf` - Play the 3 selected Partner Stories.
 * `/` - Will let you iterate over all rule questions.
 
+### Module URLs
+
+#### Sentence Writing
+
+The module url for sentence writing is `/play/sw?uid&student`. It is assumed that LMS will add
+a `uid` parameter identifying the id of the sentence writing activity in Quill Grammar.
+The LMS may also pass a `student` parameter to identify the student.
+
 Firebase Data
 =============
 


### PR DESCRIPTION
This adds documentation to the Quill Grammar Readme with the specific information regarding the Module URLs we need to tell the LMS about.