### PR TITLE
Convert proofreading passage input into a directive with fewer watchers

### DIFF
--- a/src/scripts/app/play/proofreadings/module.js
+++ b/src/scripts/app/play/proofreadings/module.js
@@ -33,4 +33,5 @@ module.exports = angular.module('quill-grammar.play.proofreadings', [
 })
 .directive('ngSize', require('./ngSize.js'))
 .directive('proofreadingErrorTooltip', require('./errorTooltip/directive.js'))
+.directive('passageWordInput', require('./passageWordInput/directive.js'))
 .controller('ProofreadingPlayCtrl', require('./controller.js'));

--- a/src/scripts/app/play/proofreadings/passage.html
+++ b/src/scripts/app/play/proofreadings/passage.html
@@ -1,19 +1,7 @@
 <div class="passage">
   <div ng-class="{'word':true, 'error-tooltip-item': !word.isBr()}" ng-repeat="(index, word) in proofreadingPassage.words" id="error-tooltip-scroll-{{index}}">
     <p ng-bind-html="space" ng-show="word.isBr()" id="break-binding-point-{{index}}"></p>
-    <input
-      autofocus="$first"
-      ng-show="!word.isBr()"
-      type="text"
-      ng-class="{focused: word.isFocused, incorrectError: word.hasIncorrectError(), notNecessaryError: word.hasNotNecessaryError(), changed: word.text !== word.responseText, correct: word.hasCorrect(), underlined: needsUnderlining(word), tooltipped: word.tooltip.style}"
-      ng-readonly="proofreadingPassage.submitted"
-      ng-focus="word.isFocused = true"
-      ng-change="proofreadingPassage.onInputChange(word)"
-      ng-blur="word.isFocused = false"
-      ng-size="{{word.responseText.length}}"
-      ng-trim="false"
-      ng-model="word.responseText">
-    </input>
+    <passage-word-input></passage-word-input>
     <proofreading-error-tooltip></proofreading-error-tooltip>
   </div>
 </div>

--- a/src/scripts/app/play/proofreadings/passageWordInput/directive.js
+++ b/src/scripts/app/play/proofreadings/passageWordInput/directive.js
@@ -1,0 +1,48 @@
+'use strict';
+
+module.exports =
+/*@ngInject*/
+function ($rootScope) {
+  return {
+    restrict: 'E',
+    templateUrl: 'passage-word-input.html',
+    link: function (scope, element) {
+      var word = scope.word;
+      var $input = element.find('input');
+      // Initialize input value.
+      $input.val(word.responseText);
+
+      function hideBreakTags() {
+        if (word.isBr()) {
+          element.css('display', 'none');
+        } else {
+          element.css('display', 'inline');
+        }
+      }
+
+      hideBreakTags();
+
+      // Replace ng-focus
+      element.on('focus', function () {
+        this.addClass('focus');
+      });
+
+      // Replace ng-blur
+      element.on('blur', function () {
+        this.removeClass('focus');
+      });
+
+      element.on('input', function () {
+        // Replace ng-model
+        var newValue = $input.val();
+        word.responseText = newValue;
+        // Replace ng-change
+        scope.proofreadingPassage.onInputChange(word);
+        $rootScope.$apply();
+
+        // Replace ng-show
+        hideBreakTags();
+      });
+    }
+  };
+};

--- a/src/scripts/app/play/proofreadings/passageWordInput/passage-word-input.html
+++ b/src/scripts/app/play/proofreadings/passageWordInput/passage-word-input.html
@@ -1,0 +1,7 @@
+<input
+  type="text"
+  ng-class="{incorrectError: word.hasIncorrectError(), notNecessaryError: word.hasNotNecessaryError(), changed: word.text !== word.responseText, correct: word.hasCorrect(), underlined: needsUnderlining(word), tooltipped: word.tooltip.style}"
+  ng-readonly="proofreadingPassage.submitted"
+  ng-size="{{word.responseText.length}}"
+  ng-trim="false">
+</input>


### PR DESCRIPTION
This seems to improve the gameplay responsiveness once the app has already finished loading, but it's unclear whether it helps with the initial problem of the slow page / app load on iPads. It's up on staging now so someone else might want to look and see if they think it's helping.

@wlaurance @petergault @elliotmandel 