### PR TITLE
Fix #160. Add a CSS spinner and hide it after the app core module loads

### DIFF
--- a/src/scripts/app/core/core.run.js
+++ b/src/scripts/app/core/core.run.js
@@ -4,6 +4,10 @@ module.exports =
 
 /*@ngInject*/
 function (QuillFirebaseAuthService, QuillOAuthService, $rootScope) {
+  // Turn off the loading spinner.
+  angular.element(document.getElementsByClassName('loading-spinner'))
+    .css('display', 'none');
+
   // Always authenticate with Firebase.
   QuillFirebaseAuthService.authenticate();
 

--- a/src/scripts/index.jade
+++ b/src/scripts/index.jade
@@ -18,6 +18,9 @@ html(ng-app='quill-grammar', ng-strict-di)
     //- inject:css
     //- endinject
   body
+    .loading-spinner
+      .three-quarters-loader
+
     ui-view
     //- inject:js
     //- endinject

--- a/src/styles/_spinner.scss
+++ b/src/styles/_spinner.scss
@@ -1,0 +1,52 @@
+// From: http://www.css-spinners.com/css/spinner/three-quarters.css
+
+@-moz-keyframes three-quarters-loader {
+  0% {
+    -moz-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -moz-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes three-quarters-loader {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes three-quarters-loader {
+  0% {
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+/* :not(:required) hides this rule from IE9 and below */
+.three-quarters-loader:not(:required) {
+  -moz-animation: three-quarters-loader 1250ms infinite linear;
+  -webkit-animation: three-quarters-loader 1250ms infinite linear;
+  animation: three-quarters-loader 1250ms infinite linear;
+  border: 64px solid #38e;
+  border-right-color: transparent;
+  border-radius: 128px;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  text-indent: -9999px;
+  width: 256px;
+  height: 256px;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -21,5 +21,11 @@ body {
   }
 }
 
+.loading-spinner {
+  text-align: center;
+}
+
+@import "spinner";
+
 @import "play/base.scss";
 @import "my-refills/progress-bar.scss";


### PR DESCRIPTION
The spinner is currently huge. It would be easy to make it smaller, but the original seemed too small.

It seems to do the trick.

@petergault @wlaurance 