### PR TITLE
Bug/fourth column in grammar concepts is a dup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "karma-phantomjs-launcher": "^0.2.0",
     "karma-sourcemap-loader": "^0.3.5",
     "mocha": "^2.2.5",
-    "phantomjs": "^1.9.17"
+    "phantomjs": "^1.9.17",
+    "protractor": "^2.5.1"
   },
   "browser": {
     "angular": "./bower_components/angular/angular.min.js",

--- a/src/scripts/app/cms/concepts/concepts.cms.html
+++ b/src/scripts/app/cms/concepts/concepts.cms.html
@@ -42,7 +42,7 @@
       <td>{{c.concept_level_2.name}}</td>
       <td>{{c.concept_level_1.name}}</td>
       <td>{{c.concept_level_0.name}}</td>
-      <td>{{getQuestionLength(c.questions)}}</td>
+      <td>{{c.questionCount}}</td>
       <td>{{c.ruleNumber}}</td>
       <td><a ui-sref="cms-concepts-view({id: c.$id})">View</a></td>
     </tr>

--- a/src/scripts/app/cms/concepts/concepts.cms.html
+++ b/src/scripts/app/cms/concepts/concepts.cms.html
@@ -1,5 +1,5 @@
 <div class="concept-search">
-  <input type="text" placeholder="Enter Search"></input>
+  <input type="text" placeholder="Enter Search" ng-model="searchConcept"></input>
 </div>
 <b>Total Concepts {{getTotalConcepts(concepts)}}</b>
 <p></p>
@@ -10,35 +10,35 @@
       <th>
         <a href="#" ng-click="sortType = 'concept_level_2.name'; sortReverse = !sortReverse">
             Concept Level 2
-            <span ng-show="sortType == 'concept_level_2.name'" class="fa fa-caret-down"></span>
+            <span ng-show="sortType == 'concept_level_2.name'">{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
         </a>
       </th>
       <th>
         <a href="#" ng-click="sortType = 'concept_level_1.name'; sortReverse = !sortReverse">
             Concept Level 1
-            <span ng-show="sortType == 'concept_level_1.name'" class="fa fa-caret-down"></span>
+            <span ng-show="sortType == 'concept_level_1.name'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
         </a>
       </th>
       <th>
         <a href="#" ng-click="sortType = 'concept_level_0.name'; sortReverse = !sortReverse">
             Concept Level 0
-            <span ng-show="sortType == 'concept_level_0.name'" class="fa fa-caret-down"></span>
+            <span ng-show="sortType == 'concept_level_0.name'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
         </a>
       </th>
       <th>
-        <a href="#" ng-click="sortType = 'questions'; sortReverse = !sortReverse">
+        <a href="#" ng-click="sortType = 'questionCount'; sortReverse = !sortReverse">
             Questions
-            <span ng-show="sortType == 'questions'" class="fa fa-caret-down"></span>
+            <span ng-show="sortType == 'questionCount'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
         </a>
       </th>
       <th>
         <a href="#" ng-click="sortType = 'ruleNumber'; sortReverse = !sortReverse">
             Rule Number
-            <span ng-show="sortType == 'ruleNumber'" class="fa fa-caret-down"></span>
+            <span ng-show="sortType == 'ruleNumber'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
         </a></th>
       <th>View</th>
     </tr>
-    <tr ng-repeat="c in concepts | orderBy:sortType:sortReverse">
+    <tr ng-repeat="c in concepts | orderBy:sortType:sortReverse | filter:searchConcept">
       <td>{{c.concept_level_2.name}}</td>
       <td>{{c.concept_level_1.name}}</td>
       <td>{{c.concept_level_0.name}}</td>

--- a/src/scripts/app/cms/concepts/concepts.cms.html
+++ b/src/scripts/app/cms/concepts/concepts.cms.html
@@ -6,46 +6,50 @@
 <b>Total Questions {{getTotalQuestions(concepts)}}</b>
 <div class="concept-list">
   <table>
-    <tr>
-      <th>
-        <a href="#" ng-click="sortType = 'concept_level_2.name'; sortReverse = !sortReverse">
-            Concept Level 2
-            <span ng-show="sortType == 'concept_level_2.name'">{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
-        </a>
-      </th>
-      <th>
-        <a href="#" ng-click="sortType = 'concept_level_1.name'; sortReverse = !sortReverse">
-            Concept Level 1
-            <span ng-show="sortType == 'concept_level_1.name'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
-        </a>
-      </th>
-      <th>
-        <a href="#" ng-click="sortType = 'concept_level_0.name'; sortReverse = !sortReverse">
-            Concept Level 0
-            <span ng-show="sortType == 'concept_level_0.name'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
-        </a>
-      </th>
-      <th>
-        <a href="#" ng-click="sortType = 'questionCount'; sortReverse = !sortReverse">
-            Questions
-            <span ng-show="sortType == 'questionCount'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
-        </a>
-      </th>
-      <th>
-        <a href="#" ng-click="sortType = 'ruleNumber'; sortReverse = !sortReverse">
-            Rule Number
-            <span ng-show="sortType == 'ruleNumber'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
-        </a></th>
-      <th>View</th>
-    </tr>
-    <tr ng-repeat="c in concepts | orderBy:sortType:sortReverse | filter:searchConcept">
-      <td>{{c.concept_level_2.name}}</td>
-      <td>{{c.concept_level_1.name}}</td>
-      <td>{{c.concept_level_0.name}}</td>
-      <td>{{c.questionCount}}</td>
-      <td>{{c.ruleNumber}}</td>
-      <td><a ui-sref="cms-concepts-view({id: c.$id})">View</a></td>
-    </tr>
+    <thead>
+      <tr>
+        <th>
+          <a href="#" ng-click="sortType = 'concept_level_2.name'; sortReverse = !sortReverse">
+              Concept Level 2
+              <span ng-show="sortType == 'concept_level_2.name'">{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
+          </a>
+        </th>
+        <th>
+          <a href="#" ng-click="sortType = 'concept_level_1.name'; sortReverse = !sortReverse">
+              Concept Level 1
+              <span ng-show="sortType == 'concept_level_1.name'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
+          </a>
+        </th>
+        <th>
+          <a href="#" ng-click="sortType = 'concept_level_0.name'; sortReverse = !sortReverse">
+              Concept Level 0
+              <span ng-show="sortType == 'concept_level_0.name'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
+          </a>
+        </th>
+        <th>
+          <a href="#" ng-click="sortType = 'questionCount'; sortReverse = !sortReverse">
+              Questions
+              <span ng-show="sortType == 'questionCount'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
+          </a>
+        </th>
+        <th>
+          <a href="#" ng-click="sortType = 'ruleNumber'; sortReverse = !sortReverse">
+              Rule Number
+              <span ng-show="sortType == 'ruleNumber'" >{{ sortReverse ? "&#x25B2;" : "&#x25BC;" }}</span>
+          </a></th>
+        <th>View</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="c in concepts | orderBy:sortType:sortReverse | filter:searchConcept">
+        <td>{{c.concept_level_2.name}}</td>
+        <td>{{c.concept_level_1.name}}</td>
+        <td>{{c.concept_level_0.name}}</td>
+        <td>{{c.questionCount}}</td>
+        <td>{{c.ruleNumber}}</td>
+        <td><a ui-sref="cms-concepts-view({id: c.$id})">View</a></td>
+      </tr>
+    </tbody>
   </table>
 <div class="concept-create">
   <a ui-sref="cms-concepts-create()"><button>Create Concepts</button></a>

--- a/src/scripts/app/cms/concepts/concepts.cms.html
+++ b/src/scripts/app/cms/concepts/concepts.cms.html
@@ -1,6 +1,5 @@
 <div class="concept-search">
   <input type="text" placeholder="Enter Search"></input>
-  <button>Search</button>
 </div>
 <b>Total Concepts {{getTotalConcepts(concepts)}}</b>
 <p></p>

--- a/src/scripts/app/cms/concepts/concepts.cms.html
+++ b/src/scripts/app/cms/concepts/concepts.cms.html
@@ -11,7 +11,6 @@
       <th>Concept Level 2</th>
       <th>Concept Level 1</th>
       <th>Concept Level 0</th>
-      <th>Concept Name</th>
       <th>Questions</th>
       <th>Rule Number</th>
       <th>View</th>
@@ -20,7 +19,6 @@
       <td>{{c.concept_level_2.name}}</td>
       <td>{{c.concept_level_1.name}}</td>
       <td>{{c.concept_level_0.name}}</td>
-      <td>{{c.name}}</td>
       <td>{{getQuestionLength(c.questions)}}</td>
       <td>{{c.ruleNumber}}</td>
       <td><a ui-sref="cms-concepts-view({id: c.$id})">View</a></td>

--- a/src/scripts/app/cms/concepts/concepts.cms.html
+++ b/src/scripts/app/cms/concepts/concepts.cms.html
@@ -8,14 +8,38 @@
 <div class="concept-list">
   <table>
     <tr>
-      <th>Concept Level 2</th>
-      <th>Concept Level 1</th>
-      <th>Concept Level 0</th>
-      <th>Questions</th>
-      <th>Rule Number</th>
+      <th>
+        <a href="#" ng-click="sortType = 'concept_level_2.name'; sortReverse = !sortReverse">
+            Concept Level 2
+            <span ng-show="sortType == 'concept_level_2.name'" class="fa fa-caret-down"></span>
+        </a>
+      </th>
+      <th>
+        <a href="#" ng-click="sortType = 'concept_level_1.name'; sortReverse = !sortReverse">
+            Concept Level 1
+            <span ng-show="sortType == 'concept_level_1.name'" class="fa fa-caret-down"></span>
+        </a>
+      </th>
+      <th>
+        <a href="#" ng-click="sortType = 'concept_level_0.name'; sortReverse = !sortReverse">
+            Concept Level 0
+            <span ng-show="sortType == 'concept_level_0.name'" class="fa fa-caret-down"></span>
+        </a>
+      </th>
+      <th>
+        <a href="#" ng-click="sortType = 'questions'; sortReverse = !sortReverse">
+            Questions
+            <span ng-show="sortType == 'questions'" class="fa fa-caret-down"></span>
+        </a>
+      </th>
+      <th>
+        <a href="#" ng-click="sortType = 'ruleNumber'; sortReverse = !sortReverse">
+            Rule Number
+            <span ng-show="sortType == 'ruleNumber'" class="fa fa-caret-down"></span>
+        </a></th>
       <th>View</th>
     </tr>
-    <tr ng-repeat="c in concepts">
+    <tr ng-repeat="c in concepts | orderBy:sortType:sortReverse">
       <td>{{c.concept_level_2.name}}</td>
       <td>{{c.concept_level_1.name}}</td>
       <td>{{c.concept_level_0.name}}</td>

--- a/src/scripts/app/cms/concepts/controller.js
+++ b/src/scripts/app/cms/concepts/controller.js
@@ -6,6 +6,9 @@ module.exports =
 function ConceptsCmsCtrl (
   $scope, ConceptsFBService, _
 ) {
+  $scope.sortType       = 'concept_level_2.name'; // set the default sort type
+  $scope.sortReverse    = false;  // set the default sort order
+  $scope.searchConcept  = '';     // set the default search/filter term
   ConceptsFBService.get().then(function (c) {
     $scope.concepts = c;
   });

--- a/src/scripts/app/cms/concepts/controller.js
+++ b/src/scripts/app/cms/concepts/controller.js
@@ -30,10 +30,10 @@ function ConceptsCmsCtrl (
     });
   };
 
-  function addQuestionCountToConcepts (concepts) {
+  function addQuestionCountToConcepts(concepts) {
     return _.map(concepts, function (c) {
       c.questionCount = _.keys(c.questions).length;
       return c;
     });
-  };
+  }
 };

--- a/src/scripts/app/cms/concepts/controller.js
+++ b/src/scripts/app/cms/concepts/controller.js
@@ -10,7 +10,7 @@ function ConceptsCmsCtrl (
   $scope.sortReverse    = false;  // set the default sort order
   $scope.searchConcept  = '';     // set the default search/filter term
   ConceptsFBService.get().then(function (c) {
-    $scope.concepts = c;
+    $scope.concepts = addQuestionCountToConcepts(c);
   });
 
   $scope.getQuestionLength = function (questions) {
@@ -27,6 +27,13 @@ function ConceptsCmsCtrl (
         sum = 0;
       }
       return Number(sum) + Number(_.keys(c.questions).length);
+    });
+  };
+
+  function addQuestionCountToConcepts (concepts) {
+    return _.map(concepts, function (c) {
+      c.questionCount = _.keys(c.questions).length;
+      return c;
     });
   };
 };

--- a/test/e2e/cms.js
+++ b/test/e2e/cms.js
@@ -1,0 +1,55 @@
+describe('The concept table page', function(){
+  it('should be able to authenticate and redirect back to the page', function(){
+		browser.get('http://localhost:3001/cms/concepts/');
+    
+		var emailInput = browser.driver.findElement(by.id('user_email'));
+		emailInput.sendKeys('admin');
+
+		var passwordInput = browser.driver.findElement(by.id('user_password'));
+		passwordInput.sendKeys('admin');  //you should not commit this to VCS
+
+		var signInButton = browser.driver.findElement(by.name('commit'));
+		signInButton.click();
+    
+		expect(browser.getTitle()).toEqual('http://localhost:3001/cms/concepts');
+	});
+
+	it('should be able to search the list', function(){
+	  browser.get('http://localhost:3001/cms/concepts/');
+	  
+	  var EC = protractor.ExpectedConditions;
+		var e = element(by.css('tbody tr:first-child'));
+		browser.wait(EC.presenceOf(e), 10000);
+		
+		var searchInput = element(by.model('searchConcept'));
+		searchInput.sendKeys('428');
+		
+		var rows = element.all(by.css('tbody tr'));
+		expect(rows.count()).toEqual(1);
+	});
+
+	it('should have rows in the table', function(){
+		var EC = protractor.ExpectedConditions;
+		var e = element(by.css('tbody tr:first-child'));
+		browser.wait(EC.presenceOf(e), 10000);
+		expect(e.isPresent()).toBeTruthy();
+	});
+
+	it('should be sortable by clicking on the table header', function(){
+	  browser.get('http://localhost:3001/cms/concepts/');
+	  
+	  var EC = protractor.ExpectedConditions;
+		var e = element(by.css('tbody tr:first-child'));
+		browser.wait(EC.presenceOf(e), 10000);
+		
+		var topRow = element(by.css('tbody tr:first-child'));
+		var bottomRow = element(by.css('tbody tr:last-child'));
+	  expect(topRow).not.toEqual(bottomRow);
+
+	  var button = element(by.css('th:first-child a'));
+		button.click();
+	
+		var newTopRow = element(by.css('tbody tr:first-child'));
+	  expect(newTopRow).not.toEqual(bottomRow);
+	});
+});

--- a/test/e2e/cms.js
+++ b/test/e2e/cms.js
@@ -1,55 +1,63 @@
-describe('The concept table page', function(){
-  it('should be able to authenticate and redirect back to the page', function(){
-		browser.get('http://localhost:3001/cms/concepts/');
-    
-		var emailInput = browser.driver.findElement(by.id('user_email'));
-		emailInput.sendKeys('admin');
+/* global browser */
+/* global element */
+/* global protractor */
+/* global by */
+/* global e */
 
-		var passwordInput = browser.driver.findElement(by.id('user_password'));
-		passwordInput.sendKeys('admin');  //you should not commit this to VCS
+'use strict';
 
-		var signInButton = browser.driver.findElement(by.name('commit'));
-		signInButton.click();
-    
-		expect(browser.getTitle()).toEqual('http://localhost:3001/cms/concepts');
-	});
-
-	it('should have rows in the table', function(){
-		waitForTableToLoad();
-		expect(e.isPresent()).toBeTruthy();
-	});
-
-	it('should be able to search the list', function(){
-	  browser.get('http://localhost:3001/cms/concepts/');
-	  
-	  waitForTableToLoad();
-		
-		var searchInput = element(by.model('searchConcept'));
-		searchInput.sendKeys('428');
-		
-		var rows = element.all(by.css('tbody tr'));
-		expect(rows.count()).toEqual(1);
-	});
-
-	it('should be sortable by clicking on the table header', function(){
-	  browser.get('http://localhost:3001/cms/concepts/');
-	  
-	  waitForTableToLoad();
-		
-		var topRow = element(by.css('tbody tr:first-child'));
-		var bottomRow = element(by.css('tbody tr:last-child'));
-	  expect(topRow).not.toEqual(bottomRow);
-
-	  var button = element(by.css('th:first-child a'));
-		button.click();
-	
-		var newTopRow = element(by.css('tbody tr:first-child'));
-	  expect(newTopRow).not.toEqual(bottomRow);
-	});
-});
-
-function waitForTableToLoad(){
-	var EC = protractor.ExpectedConditions;
-	var e = element(by.css('tbody tr:first-child'));
-	browser.wait(EC.presenceOf(e), 10000);
+function waitForTableToLoad() {
+  var EC = protractor.ExpectedConditions;
+  var e = element(by.css('tbody tr:first-child'));
+  browser.wait(EC.presenceOf(e), 10000);
 }
+
+describe('The concept table page', function () {
+  it('should be able to authenticate and redirect back to the page', function () {
+    browser.get('http://localhost:3001/cms/concepts/');
+
+    var emailInput = browser.driver.findElement(by.id('user_email'));
+    emailInput.sendKeys('admin');
+
+    var passwordInput = browser.driver.findElement(by.id('user_password'));
+    passwordInput.sendKeys('admin');  //you should not commit this to VCS
+
+    var signInButton = browser.driver.findElement(by.name('commit'));
+    signInButton.click();
+
+    expect(browser.getTitle()).toEqual('http://localhost:3001/cms/concepts');
+  });
+
+  it('should have rows in the table', function () {
+    waitForTableToLoad();
+    expect(e.isPresent()).toBeTruthy();
+  });
+
+  it('should be able to search the list', function () {
+    browser.get('http://localhost:3001/cms/concepts/');
+
+    waitForTableToLoad();
+
+    var searchInput = element(by.model('searchConcept'));
+    searchInput.sendKeys('428');
+
+    var rows = element.all(by.css('tbody tr'));
+    expect(rows.count()).toEqual(1);
+  });
+
+  it('should be sortable by clicking on the table header', function () {
+    browser.get('http://localhost:3001/cms/concepts/');
+
+    waitForTableToLoad();
+
+    var topRow = element(by.css('tbody tr:first-child'));
+    var bottomRow = element(by.css('tbody tr:last-child'));
+    expect(topRow).not.toEqual(bottomRow);
+
+    var button = element(by.css('th:first-child a'));
+    button.click();
+
+    var newTopRow = element(by.css('tbody tr:first-child'));
+    expect(newTopRow).not.toEqual(bottomRow);
+  });
+});

--- a/test/e2e/cms.js
+++ b/test/e2e/cms.js
@@ -14,12 +14,15 @@ describe('The concept table page', function(){
 		expect(browser.getTitle()).toEqual('http://localhost:3001/cms/concepts');
 	});
 
+	it('should have rows in the table', function(){
+		waitForTableToLoad();
+		expect(e.isPresent()).toBeTruthy();
+	});
+
 	it('should be able to search the list', function(){
 	  browser.get('http://localhost:3001/cms/concepts/');
 	  
-	  var EC = protractor.ExpectedConditions;
-		var e = element(by.css('tbody tr:first-child'));
-		browser.wait(EC.presenceOf(e), 10000);
+	  waitForTableToLoad();
 		
 		var searchInput = element(by.model('searchConcept'));
 		searchInput.sendKeys('428');
@@ -28,19 +31,10 @@ describe('The concept table page', function(){
 		expect(rows.count()).toEqual(1);
 	});
 
-	it('should have rows in the table', function(){
-		var EC = protractor.ExpectedConditions;
-		var e = element(by.css('tbody tr:first-child'));
-		browser.wait(EC.presenceOf(e), 10000);
-		expect(e.isPresent()).toBeTruthy();
-	});
-
 	it('should be sortable by clicking on the table header', function(){
 	  browser.get('http://localhost:3001/cms/concepts/');
 	  
-	  var EC = protractor.ExpectedConditions;
-		var e = element(by.css('tbody tr:first-child'));
-		browser.wait(EC.presenceOf(e), 10000);
+	  waitForTableToLoad();
 		
 		var topRow = element(by.css('tbody tr:first-child'));
 		var bottomRow = element(by.css('tbody tr:last-child'));
@@ -53,3 +47,9 @@ describe('The concept table page', function(){
 	  expect(newTopRow).not.toEqual(bottomRow);
 	});
 });
+
+function waitForTableToLoad(){
+	var EC = protractor.ExpectedConditions;
+	var e = element(by.css('tbody tr:first-child'));
+	browser.wait(EC.presenceOf(e), 10000);
+}

--- a/test/e2e/conf.js
+++ b/test/e2e/conf.js
@@ -1,5 +1,5 @@
 exports.config = {
   framework: 'jasmine2',
-	seleniumAddress: 'http://localhost:4444/wd/hub',
+  seleniumAddress: 'http://localhost:4444/wd/hub',
   specs: ['cms.js']
-}
+};

--- a/test/e2e/conf.js
+++ b/test/e2e/conf.js
@@ -1,0 +1,5 @@
+exports.config = {
+  framework: 'jasmine2',
+	seleniumAddress: 'http://localhost:4444/wd/hub',
+  specs: ['cms.js']
+}


### PR DESCRIPTION
First of all I removed the duplicate 4th column in the table. 

Then I added buttons to the table headers, when clicked they set the sortType (to the data in that column) and if necessary invert the sort direction. 

I have also added the ability to filter the table using the search bar. The results may seem a little odd, but this is because it searches through the entire list of questions as well as the names of the concepts. This really helps when you are looking for a particular question in a concept.

Finally I've added some EndToEnd tests with protractor to check these interactions work. Protractor doesn't support waiting for promises, so the waitForTableToLoad function was implemented so check that firebase has returned the data before trying to filter/sort and empty table.

Instructions for running Protractor: http://angular.github.io/protractor/#/tutorial

```
protractor spec/e2e/conf.js
```