### PR TITLE
Display concept level 1 in SW questions to avoid giving away the answer.

### DIFF
--- a/src/scripts/app/play/sentences/sentences.play.html
+++ b/src/scripts/app/play/sentences/sentences.play.html
@@ -5,7 +5,7 @@
   </div>
   <div class="sentence-writing-heading">
     <div class="left">
-      <h2>{{currentConcept.concept_level_0.name}}</h2>
+      <h2>{{currentConcept.concept_level_1.name}}</h2>
       <sentence-writing-concept-overview></sentence-writing-concept-overview>
       <sentence-writing-instructions current-rule="currentConcept"></sentence-writing-instructions>
     </div>


### PR DESCRIPTION
Small tweak so that the answers to sentence writing exercises aren't given away by the title.