### PR TITLE
Disable autocorrect features of the browser.

### DIFF
--- a/src/scripts/app/play/proofreadings/passageWordInput/passage-word-input.html
+++ b/src/scripts/app/play/proofreadings/passageWordInput/passage-word-input.html
@@ -3,5 +3,7 @@
   ng-class="{incorrectError: word.hasIncorrectError(), notNecessaryError: word.hasNotNecessaryError(), changed: word.text !== word.responseText, correct: word.hasCorrect(), underlined: needsUnderlining(word), tooltipped: word.tooltip.style}"
   ng-readonly="proofreadingPassage.submitted"
   ng-size="{{word.responseText.length}}"
-  ng-trim="false">
+  ng-trim="false"
+  autocapitalize="off"
+  autocorrect="off">
 </input>


### PR DESCRIPTION
https://github.com/empirical-org/Quill-Grammar/issues/212 Prevents Device auto correct being either too helpful, by correcting spelling, or being unhelpful by autocapitalizing every word.