### PR TITLE
Track errors in New Relic

### DIFF
--- a/src/scripts/services/analytics.js
+++ b/src/scripts/services/analytics.js
@@ -62,13 +62,49 @@ angular.module('quill-grammar.services.analytics', [
   $httpProvider.interceptors.push('errorHttpInterceptor');
 }])
 
-.factory('$exceptionHandler', ['$window', function ($window) {
+.factory("errors", ['$window', '$log', function errorLoggerFactory( $window, $log ) {
+  // Return the public API.
+  return({
+    report: report
+  });
+  // I report errors to the remote server.
+  function report( error ) {
+    // In this case, we're going to be using New Relic's Browser API to
+    // report JavaScript errors that originate from within the AngularJS
+    // application try / catch blocks (which is why the global error
+    // handler doesn't see them). But, since New Relic is a per-server
+    // cost, we might not have it enabled in every environment. Let's
+    // check to see if the API exists before we try to use it.
+    if ( $window.NREUM && $window.NREUM.noticeError ) {
+      try {
+        $window.NREUM.noticeError( error );
+      // If logging errors is causing an error, just swallow those
+      // errors; attempting to log these errors might lock the browser
+      // in an infinite loop.
+      } catch ( newRelicError ) {
+        $log.error( newRelicError );
+      }
+    } else {
+      $log.info( "New Relic not available to record error." );
+    }
+    if ($window.atatus) {
+      $window.atatus.notify(error);
+    } else {
+      $log.info( "Atatus not available to record error." );
+    }
+    $log.error(error);
+  }
+}])
+
+.factory('$exceptionHandler', ['$window', 'errors', function ($window, errors) {
   return function (exception, cause) {
     if (exception.stack) {
       exception.stack = exception.stack.replace('new <anonymous>', '<anonymous>');
     }
-    if ($window.atatus) {
-      $window.atatus.notify(exception);
+
+    if ($window.NREUM) {
+      $window.NREUM.noticeError(exception);
     }
+    errors.report(exception);
   };
 }]);


### PR DESCRIPTION
Pass the errors to new relic in addition to Atatus, and refactor the error handlers