### PR TITLE
Don’t save to firebase without a session id

### DIFF
--- a/src/scripts/app/play/proofreadings/controller.js
+++ b/src/scripts/app/play/proofreadings/controller.js
@@ -150,7 +150,9 @@ function ProofreadingPlayCtrl (
 
   function submitConceptResult(sessionId, word, meta) {
     var conceptUid = $scope.proofreadingPassage.getGrammaticalConceptData(word).concept_level_0.uid;
-    ConceptResult.saveToFirebase(sessionId, conceptUid, meta);
+    if (sessionId) {
+      ConceptResult.saveToFirebase(sessionId, conceptUid, meta);
+    }
   }
 
   $scope.submitPassage = function () {


### PR DESCRIPTION
Control flow to fix anonymous session of Proofreader.