### PR TITLE
disallows text selection, prohibiting drag and drop copying

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -19,6 +19,14 @@ body {
   p {
     font-size: 15px;
   }
+  p.prompt {
+      -webkit-touch-callout: none;
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+  }
 }
 
 .loading-spinner {


### PR DESCRIPTION
students were dragging and dropping the prompts to answer questions without typing.