### PR TITLE
Updating the check work button styling to be more mobile friendly

### DIFF
--- a/src/styles/play/proofreading/submit-panel.scss
+++ b/src/styles/play/proofreading/submit-panel.scss
@@ -1,10 +1,13 @@
+$mobile: new-breakpoint(max-width 600px);
 $message-width: 9;
 $button-width: 3;
+$message-width-mobile: 0;
+$button-width-mobile: 12;
 div.passage-submit-panel {
   background-color: $gray;
   box-shadow: 0 500px 2px 500px $gray;
   margin-top: 30px;
-  padding-right: 30px;
+  padding: 0px 30px;
   height: 116px;
   &.passage-submitted {
     height: 348px;
@@ -18,6 +21,12 @@ div.passage-submit-panel {
     @include span-columns($button-width);
     &.no-message {
       @include shift($message-width);
+    }
+    @include media($mobile) {
+      @include span-columns($button-width-mobile);
+      &.no-message {
+        @include shift($message-width-mobile);
+      }
     }
   }
 }


### PR DESCRIPTION
The check work button text would overflow the button on mobile. This
commit adjusts the styling a bit for mobile so that the text fits in
the button and that on mobile the button is bigger and more mobile
friendly.

@ddmck 